### PR TITLE
development/apache-ant: update README

### DIFF
--- a/development/apache-ant/README
+++ b/development/apache-ant/README
@@ -1,8 +1,12 @@
 Apache Ant is a Java-based build tool - like make, but without make's
-wrinkles.  :-)
+wrinkles. :-)
 
-Ant is extended using Java classes.  The configuration files are XML-based,
-calling out a target tree where tasks get executed.  Each task is run by an
+Ant is extended using Java classes. The configuration files are XML-based,
+calling out a target tree where tasks get executed. Each task is run by an
 object that implements a Task interface.
 
 This package is using upstream's recommendation of ANT_HOME=/usr/share/ant
+
+apache-ant uses `javac` and friends to compile java projects. Using the stock
+'gcc-java' package, by exporting JAVA_HOME=/usr/lib64/jvm envirnoment
+variable. Or from slackbuilds.org, one of jdk, openjdk* works just fine.

--- a/development/apache-ant/apache-ant.SlackBuild
+++ b/development/apache-ant/apache-ant.SlackBuild
@@ -30,7 +30,7 @@
 PRGNAM=apache-ant
 VERSION=${VERSION:-1.9.7}
 ARCH=noarch
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 
 TEAM=$(echo $PRGNAM | cut -d- -f1)
@@ -83,6 +83,7 @@ cd -
 mkdir -p $PKG/usr/doc/${PRGNAM}-$VERSION
 cp -a INSTALL KEYS NOTICE README WHATSNEW manual/* $PKG/usr/doc/${PRGNAM}-$VERSION
 cat $CWD/${PRGNAM}.SlackBuild > $PKG/usr/doc/${PRGNAM}-$VERSION/${PRGNAM}.SlackBuild
+cat $CWD/README > $PKG/usr/doc/${PRGNAM}-$VERSION/README.SBo
 
 mkdir -p $PKG/install
 cat $CWD/slack-desc > $PKG/install/slack-desc

--- a/development/apache-ant/apache-ant.info
+++ b/development/apache-ant/apache-ant.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://archive.apache.org/dist/ant/binaries/apache-ant-1.9.7-bin.tar.
 MD5SUM="99a86981333a0ff39bb56c963d1f492b"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="jdk"
+REQUIRES="%README%"
 MAINTAINER="Vincent Batts"
 EMAIL="vbatts@hashbangbash.com"


### PR DESCRIPTION
the REQUIRES= was not clear enough, and made for tricky deps chains

Reported-by: B Watson <yalhcru@gmail.com>
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>