### PR TITLE
development/golang-googlecode-gotools: fix build of go.tools

### DIFF
--- a/development/golang-googlecode-gotools/README
+++ b/development/golang-googlecode-gotools/README
@@ -6,3 +6,16 @@ language. Like godoc, a code vetting analysis utility and others.
 This also provides the import path of code.google.com/p/go.tools for
 the Go programming language. These libraries are source only.  To
 compile using the libraries, include "/usr/share/gocode" in your GOPATH
+
+This package currently builds a historic version of tools from when they were
+removed from the core golang repo.
+
+Users may wish to install updated commands, like:
+```
+go get -u golang.org/x/tools/godoc
+```
+
+or in future golang versions (>= go1.17):
+```
+go install golang.org/x/tools/gopls@latest
+```

--- a/development/golang-googlecode-gotools/golang-googlecode-gotools.SlackBuild
+++ b/development/golang-googlecode-gotools/golang-googlecode-gotools.SlackBuild
@@ -90,6 +90,7 @@ cp -a .  ${PKG}/usr/share/gocode/src/${IMPORT_PATH}
 
 export GOPATH=${PKG}/usr/share/gocode:/usr/share/gocode
 export GOBIN=${PKG}/usr/bin
+export GO111MODULE="off"
 for cmd in godoc cover vet oracle gotype html2article ; do
 	cd ./cmd/${cmd}/
 	go build -a -x -o ${GOBIN}/${cmd} .


### PR DESCRIPTION
This is a bandaid, since the package is so old. To update it would be a
rework of this SlackBuild. So, added some instructions for users that
care to install a newer version for themselves.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>