### PR TITLE
Yelpwebkit2gtk

### DIFF
--- a/academic/xiphos/README
+++ b/academic/xiphos/README
@@ -4,3 +4,6 @@ Sword project by the CrossWire Bible Society.
 
 computer reading of the text using festival has not been tested. if
 it works let me know, and i'll remove these two lines from the readme.
+
+if built with webkit2gtk4.1 then yelp also needs to be built with
+webkit2gtk4.1

--- a/academic/xiphos/xiphos.SlackBuild
+++ b/academic/xiphos/xiphos.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for xiphos
 
-# Copyright 2015-2023 Tim Dickson, email: dickson.tim@googlemail.com
+# Copyright 2015-2024 Tim Dickson, email: dickson.tim@googlemail.com
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -28,7 +28,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=xiphos
 VERSION=${VERSION:-4.2.1}
-BUILD=${BUILD:-5}
+BUILD=${BUILD:-6}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -85,6 +85,10 @@ find -L . \
 
 #patch to make work with newer glib
 echo "#define GLIB_VERSION_MIN_REQUIRED (GLIB_VERSION_2_26)" >>cmake/config.h.cmake.in
+if $(pkg-config --exists webkit2gtk.1); then  #patch for webkit2gtk4.1
+  sed -i 's/webkit2gtk-4.0/webkit2gtk-4.1/g' cmake/XiphosDependencies.cmake
+  sed -i 's/libsoup-2.4/libsoup-3.0/g' cmake/XiphosDependencies.cmake
+fi
 mkdir -p build
 cd build
 cmake -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS" \

--- a/office/gnucash/README
+++ b/office/gnucash/README
@@ -16,3 +16,5 @@ Pass WITHPYTHON="yes" to enable Python bindings for report gereration.
 
 If you want the SQL database integration, you must first have libdbi
 and libdbi-drivers installed and pass DBI="yes" to the build script.
+
+to build with webkit2gtk4.1, yelp needs to be built with webkit2gtk4.1

--- a/office/gnucash/gnucash.SlackBuild
+++ b/office/gnucash/gnucash.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=gnucash
 VERSION=${VERSION:-4.11}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -118,6 +118,12 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+if $(pkg-config --exists webkit2gtk4.1); then
+  #use webkit2gtk4.1 instead of webkit2gtk if present.
+  sed -i 's/webkit2gtk-4.0/webkit2gtk-4.1/g' CMakeLists.txt
+  sed -i 's/WebKit2Gtk4/WebKit2Gtk4.1/g' CMakeLists.txt
+fi
 
 mkdir -p build
 cd build

--- a/system/yelp/README
+++ b/system/yelp/README
@@ -2,6 +2,7 @@ yelp allows you to view documentation regarding GNOME and other
 components through a variety of formats
 
 Conflict warning: webkit2gtk and webkit2gtk4.1 conflict with each
-other. Since this depends on webkit2gtk (with 4.0 API), yelp cannot
-be used with (or even installed on the same system as) software that
-requires webkit2gtk4.1.
+other. If this is build with webkit2gtk4.1 instead of webkit2gtk,
+any software that uses it and it's deps must also be built with
+webkit2gtk4.1/soup3 instead of webkit2gtk/soup2
+

--- a/system/yelp/yelp.SlackBuild
+++ b/system/yelp/yelp.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=yelp
 VERSION=${VERSION:-42.2}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -76,6 +76,11 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
  -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+WKIT2="4-0"  #handle either webkit2gtk or webkit2gtk4.1
+if $(pkg-config --exists webkit2gtk-4.1); then
+   WKIT2="4-1"
+fi
+
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 ./configure \
@@ -87,7 +92,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --enable-static=no \
   --disable-schemas-compile \
-  --with-webkit2gtk-4-0 \
+  --with-webkit2gtk-$WKIT2 \
   --build=$ARCH-slackware-linux
 
 make


### PR DESCRIPTION
this adds webkit2gtk4.1 support for yelp, and for the packages (xiphos and gnucash(indirectly)) which use it. Note. it does not change previous build behaviour if webkit2gtk is installed but not webkit2gtk4.1. neither gmdb2 or gnucash-docs require any changes.

Hopefully this avoids contention caused by the broken state of gnome libs and applications due to libsoup3. I have not changed the listed deps as webkit2gtk4.1 support is not complete for all apps that use webkit2gtk on sbo, and some, due to abandonment by devs or other projects that used to use them, will never be updated. (eg libgdata, gfbgraph etc.)
